### PR TITLE
Add support for Laravel 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,9 @@
     "require": {
         "php": ">=5.6.4",
         "clicksend/clicksend-php": "4.0.*",
-        "illuminate/queue": "^5.1",
-        "illuminate/notifications": "^5.1",
-        "illuminate/support": "^5.1"
+        "illuminate/queue": "^5.1 || ^6.0",
+        "illuminate/notifications": "^5.1 || ^6.0",
+        "illuminate/support": "^5.1 || ^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.2",


### PR DESCRIPTION
Updates the version constraint on illuminate components to work with Laravel 6.x